### PR TITLE
Add Flask-based rate schedule manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # BehindTheMeterSolutions.com
 
-This repository hosts a simple web-based Pong game implemented in HTML5 Canvas. Open `index.html` in your browser to play.
+This project implements a small rate schedule configuration system. It uses a Flask backend with a SQLite database and a simple HTML/JavaScript front end.
+
+## Running the application
+
+Install dependencies and populate the database with the provided list of utilities:
+
+```bash
+pip install -r requirements.txt
+python load_utilities.py  # one time to create states/utilities
+python app.py
+```
+
+Open `index.html` in your browser. The page will communicate with the running Flask API on port `5000`.
+
+## Features
+
+* Import rate schedules from an Excel file.
+* Dependent drop downs for state, utility and available rate schedules.
+* Ability to view and update a selected schedule.
+* Downloadable Excel template for importing data.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,147 @@
+from flask import Flask, request, jsonify, send_file
+import sqlite3
+import os
+import pandas as pd
+from io import BytesIO
+
+DB = 'rates.db'
+app = Flask(__name__)
+
+def get_db_connection():
+    conn = sqlite3.connect(DB)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def init_db():
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute('''
+    CREATE TABLE IF NOT EXISTS states(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT UNIQUE
+    )''')
+    cur.execute('''
+    CREATE TABLE IF NOT EXISTS utilities(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        state_id INTEGER,
+        name TEXT,
+        FOREIGN KEY(state_id) REFERENCES states(id)
+    )''')
+    cur.execute('''
+    CREATE TABLE IF NOT EXISTS rate_schedules(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        utility_id INTEGER,
+        name TEXT,
+        status TEXT,
+        details TEXT,
+        FOREIGN KEY(utility_id) REFERENCES utilities(id)
+    )''')
+    conn.commit()
+    conn.close()
+
+@app.route('/initdb')
+def initdb_route():
+    init_db()
+    return 'Database initialized'
+
+@app.route('/api/states')
+def states():
+    conn = get_db_connection()
+    states = conn.execute('SELECT * FROM states ORDER BY name').fetchall()
+    conn.close()
+    return jsonify([dict(row) for row in states])
+
+@app.route('/api/utilities')
+def utilities():
+    state_id = request.args.get('state_id')
+    conn = get_db_connection()
+    if state_id:
+        utils = conn.execute('SELECT * FROM utilities WHERE state_id=? ORDER BY name', (state_id,)).fetchall()
+    else:
+        utils = conn.execute('SELECT * FROM utilities ORDER BY name').fetchall()
+    conn.close()
+    return jsonify([dict(row) for row in utils])
+
+@app.route('/api/rate_schedules')
+def rate_schedules():
+    util_id = request.args.get('utility_id')
+    conn = get_db_connection()
+    if util_id:
+        rs = conn.execute('SELECT * FROM rate_schedules WHERE utility_id=? ORDER BY name', (util_id,)).fetchall()
+    else:
+        rs = conn.execute('SELECT * FROM rate_schedules ORDER BY name').fetchall()
+    conn.close()
+    return jsonify([dict(row) for row in rs])
+
+@app.route('/api/rate_schedule/<int:sched_id>', methods=['GET', 'PUT'])
+def rate_schedule(sched_id):
+    conn = get_db_connection()
+    if request.method == 'GET':
+        row = conn.execute('SELECT * FROM rate_schedules WHERE id=?', (sched_id,)).fetchone()
+        conn.close()
+        if row:
+            return jsonify(dict(row))
+        return jsonify({'error': 'Not found'}), 404
+    else:
+        data = request.get_json()
+        conn.execute('UPDATE rate_schedules SET name=?, status=?, details=? WHERE id=?',
+                     (data['name'], data['status'], data.get('details','{}'), sched_id))
+        conn.commit()
+        conn.close()
+        return jsonify({'status': 'updated'})
+
+@app.route('/api/rate_schedule', methods=['POST'])
+def create_rate_schedule():
+    data = request.get_json()
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute('INSERT INTO rate_schedules (utility_id, name, status, details) VALUES (?, ?, ?, ?)',
+                (data['utility_id'], data['name'], data['status'], data.get('details','{}')))
+    conn.commit()
+    sched_id = cur.lastrowid
+    conn.close()
+    return jsonify({'id': sched_id})
+
+@app.route('/api/upload', methods=['POST'])
+def upload():
+    if 'file' not in request.files:
+        return 'No file', 400
+    f = request.files['file']
+    df = pd.read_excel(f)
+    init_db()
+    conn = get_db_connection()
+    cur = conn.cursor()
+    for _, row in df.iterrows():
+        state = row['State']
+        util = row['Utility']
+        name = row['Schedule']
+        status = row.get('Status','Active')
+        details = row.drop(['State','Utility','Schedule','Status']).to_json()
+        # get state id
+        cur.execute('INSERT OR IGNORE INTO states(name) VALUES(?)', (state,))
+        conn.commit()
+        cur.execute('SELECT id FROM states WHERE name=?', (state,))
+        state_id = cur.fetchone()['id']
+        cur.execute('INSERT OR IGNORE INTO utilities(state_id,name) VALUES(?,?)', (state_id, util))
+        conn.commit()
+        cur.execute('SELECT id FROM utilities WHERE name=? AND state_id=?', (util, state_id))
+        util_id = cur.fetchone()['id']
+        cur.execute('INSERT INTO rate_schedules (utility_id,name,status,details) VALUES(?,?,?,?)',
+                    (util_id, name, status, details))
+    conn.commit()
+    conn.close()
+    return 'Uploaded'
+
+@app.route('/api/template')
+def template():
+    # Provide an Excel template
+    cols = ['State','Utility','Schedule','Status','Description']
+    df = pd.DataFrame(columns=cols)
+    output = BytesIO()
+    df.to_excel(output,index=False)
+    output.seek(0)
+    return send_file(output, download_name='template.xlsx', as_attachment=True)
+
+if __name__ == '__main__':
+    init_db()
+    app.run(host='0.0.0.0', port=5000)

--- a/index.html
+++ b/index.html
@@ -2,79 +2,120 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Pong</title>
+<title>Rate Schedule Manager</title>
 <style>
-  body { margin: 0; background: #000; color: #fff; font-family: sans-serif; text-align: center; }
-  canvas { background: #222; display: block; margin: 20px auto; }
+body { font-family: Arial, sans-serif; margin: 20px; }
+label { display:block; margin-top:10px; }
+select, textarea, input { width: 300px; }
+#status { font-weight:bold; }
 </style>
 </head>
 <body>
-<canvas id="game" width="600" height="400"></canvas>
+<h1>Rate Schedule Manager</h1>
+<div>
+  <label>State
+    <select id="state"></select>
+  </label>
+  <label>Utility
+    <select id="utility"></select>
+  </label>
+  <label>Rate Schedule
+    <select id="schedule"></select>
+  </label>
+  <div id="status"></div>
+</div>
+<div>
+  <h3>Details</h3>
+  <input id="name" placeholder="Name"><br>
+  <label>Status
+    <select id="schedStatus">
+      <option value="Active">Active</option>
+      <option value="Archived">Archived</option>
+      <option value="Expired">Expired</option>
+    </select>
+  </label>
+  <label>JSON Details
+    <textarea id="details" rows="6"></textarea>
+  </label>
+  <button id="save">Save</button>
+  <button id="new">New</button>
+</div>
+<div>
+  <h3>Import from Excel</h3>
+  <input type="file" id="file">
+  <button id="upload">Upload</button>
+  <a href="http://localhost:5000/api/template">Download Template</a>
+</div>
 <script>
-const canvas = document.getElementById('game');
-const ctx = canvas.getContext('2d');
-const paddleWidth = 10;
-const paddleHeight = 80;
-const ballSize = 10;
-let leftY = canvas.height/2 - paddleHeight/2;
-let rightY = canvas.height/2 - paddleHeight/2;
-let ballX = canvas.width/2;
-let ballY = canvas.height/2;
-let ballVX = 4;
-let ballVY = 4;
-const speed = 6;
-const keys = {};
-
-function draw(){
-  ctx.clearRect(0,0,canvas.width,canvas.height);
-  // paddles
-  ctx.fillStyle = '#fff';
-  ctx.fillRect(0, leftY, paddleWidth, paddleHeight);
-  ctx.fillRect(canvas.width - paddleWidth, rightY, paddleWidth, paddleHeight);
-  // ball
-  ctx.fillRect(ballX - ballSize/2, ballY - ballSize/2, ballSize, ballSize);
+async function fetchStates(){
+  const res = await fetch('http://localhost:5000/api/states');
+  const data = await res.json();
+  const sel=document.getElementById('state');
+  sel.innerHTML='<option value="">Select</option>';
+  data.forEach(s=> sel.innerHTML+=`<option value="${s.id}">${s.name}</option>`);
+}
+async function fetchUtilities(){
+  const stateId=document.getElementById('state').value;
+  const res = await fetch(`http://localhost:5000/api/utilities?state_id=${stateId}`);
+  const data = await res.json();
+  const sel=document.getElementById('utility');
+  sel.innerHTML='<option value="">Select</option>';
+  data.forEach(u=> sel.innerHTML+=`<option value="${u.id}">${u.name}</option>`);
+}
+async function fetchSchedules(){
+  const utilId=document.getElementById('utility').value;
+  const res = await fetch(`http://localhost:5000/api/rate_schedules?utility_id=${utilId}`);
+  const data = await res.json();
+  const sel=document.getElementById('schedule');
+  sel.innerHTML='<option value="">Select</option>';
+  data.forEach(r=> sel.innerHTML+=`<option value="${r.id}">${r.name}</option>`);
+}
+async function loadSchedule(){
+  const id=document.getElementById('schedule').value;
+  if(!id) return;
+  const res = await fetch(`http://localhost:5000/api/rate_schedule/${id}`);
+  const data = await res.json();
+  document.getElementById('name').value=data.name;
+  document.getElementById('schedStatus').value=data.status;
+  document.getElementById('details').value=data.details;
+  document.getElementById('status').textContent=data.status;
+}
+async function saveSchedule(){
+  const id=document.getElementById('schedule').value;
+  const payload={
+    name:document.getElementById('name').value,
+    status:document.getElementById('schedStatus').value,
+    details:document.getElementById('details').value
+  };
+  if(id){
+    await fetch(`http://localhost:5000/api/rate_schedule/${id}`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+  }else{
+    payload.utility_id=document.getElementById('utility').value;
+    const res=await fetch('http://localhost:5000/api/rate_schedule',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+    const data=await res.json();
+    document.getElementById('schedule').innerHTML+=`<option value="${data.id}">${payload.name}</option>`;
+    document.getElementById('schedule').value=data.id;
+  }
+  document.getElementById('status').textContent=payload.status;
+}
+async function uploadFile(){
+  const file=document.getElementById('file').files[0];
+  if(!file) return;
+  const form=new FormData();
+  form.append('file',file);
+  await fetch('http://localhost:5000/api/upload',{method:'POST',body:form});
+  alert('Uploaded');
+  fetchStates();
 }
 
-function update(){
-  if(keys['w'] && leftY > 0) leftY -= speed;
-  if(keys['s'] && leftY < canvas.height - paddleHeight) leftY += speed;
-  if(keys['ArrowUp'] && rightY > 0) rightY -= speed;
-  if(keys['ArrowDown'] && rightY < canvas.height - paddleHeight) rightY += speed;
+document.getElementById('state').addEventListener('change',()=>{fetchUtilities();document.getElementById('schedule').innerHTML='';});
+document.getElementById('utility').addEventListener('change',()=>{fetchSchedules();});
+document.getElementById('schedule').addEventListener('change',loadSchedule);
+document.getElementById('save').addEventListener('click',saveSchedule);
+document.getElementById('new').addEventListener('click',()=>{document.getElementById('schedule').value='';document.getElementById('name').value='';document.getElementById('details').value='';});
+document.getElementById('upload').addEventListener('click',uploadFile);
 
-  ballX += ballVX;
-  ballY += ballVY;
-
-  // top/bottom
-  if(ballY < ballSize/2 || ballY > canvas.height - ballSize/2) ballVY *= -1;
-  // left paddle
-  if(ballX - ballSize/2 < paddleWidth && ballY > leftY && ballY < leftY + paddleHeight){
-    ballVX *= -1;
-    ballX = paddleWidth + ballSize/2;
-  }
-  // right paddle
-  if(ballX + ballSize/2 > canvas.width - paddleWidth && ballY > rightY && ballY < rightY + paddleHeight){
-    ballVX *= -1;
-    ballX = canvas.width - paddleWidth - ballSize/2;
-  }
-
-  // score reset if out of bounds
-  if(ballX < 0 || ballX > canvas.width){
-    ballX = canvas.width/2;
-    ballY = canvas.height/2;
-    ballVX = 4 * (Math.random() > 0.5 ? 1 : -1);
-    ballVY = 4 * (Math.random() > 0.5 ? 1 : -1);
-  }
-}
-
-function loop(){
-  update();
-  draw();
-  requestAnimationFrame(loop);
-}
-
-window.addEventListener('keydown', (e)=>{ keys[e.key] = true; });
-window.addEventListener('keyup', (e)=>{ keys[e.key] = false; });
-loop();
+fetchStates();
 </script>
 </body>
 </html>

--- a/load_utilities.py
+++ b/load_utilities.py
@@ -1,0 +1,29 @@
+import csv
+import sqlite3
+DB='rates.db'
+
+conn=sqlite3.connect(DB)
+cur=conn.cursor()
+cur.execute('CREATE TABLE IF NOT EXISTS states(id INTEGER PRIMARY KEY AUTOINCREMENT,name TEXT UNIQUE)')
+cur.execute('CREATE TABLE IF NOT EXISTS utilities(id INTEGER PRIMARY KEY AUTOINCREMENT,state_id INTEGER,name TEXT,FOREIGN KEY(state_id) REFERENCES states(id))')
+conn.commit()
+
+with open('Utilities.csv', encoding='utf-8') as f:
+    reader = csv.reader(f)
+    # skip lines until header
+    for row in reader:
+        if row and row[0].strip()=="State":
+            headers=row
+            break
+    reader = csv.DictReader(f, fieldnames=headers)
+    for row in reader:
+        state=row['State']
+        util=row['Utility Name']
+        cur.execute('INSERT OR IGNORE INTO states(name) VALUES(?)',(state,))
+        conn.commit()
+        cur.execute('SELECT id FROM states WHERE name=?',(state,))
+        state_id=cur.fetchone()[0]
+        cur.execute('INSERT OR IGNORE INTO utilities(state_id,name) VALUES(?,?)',(state_id, util))
+conn.commit()
+conn.close()
+print('Loaded utilities')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+openpyxl
+pandas


### PR DESCRIPTION
## Summary
- add Flask backend and HTML frontend for managing rate schedules
- provide helper script to load utilities into SQLite
- update README with setup instructions
- include Python dependencies

## Testing
- `python -m py_compile app.py load_utilities.py`
- `python load_utilities.py | head`
- `python app.py & sleep 5; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68786b3bfd0c8320b9e738e6484692a1